### PR TITLE
Add support for data versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@
 ## [Unreleased]
 ### Added
 - Changelog
+- Added data-version and data-default bindings
 
 ## [0.1.1] - 2016-05-18
 ### Added
 - Support for searching for index.html in folder based on URI when {URI}.html is not found
-- Travis CI badge
 
 ## 0.1.0 - 2015-11-13
 ### Added

--- a/src/glimpse/impl/default.clj
+++ b/src/glimpse/impl/default.clj
@@ -67,7 +67,8 @@
 (deftype View [view]
   IView
   (bind [this scope-selector data opts]
-    (View. (bindings/bind-scope view scope-selector data)))
+    (let [{version :version} (apply hash-map opts)]
+     (View. (bindings/bind-scope view scope-selector version data))))
 
   (render [this opts]
     (apply str (html/emit* view)))

--- a/src/glimpse/impl/default/bindings.clj
+++ b/src/glimpse/impl/default/bindings.clj
@@ -134,7 +134,7 @@
   ([nodes scope version data]
    (let [v (cond
              (nil? version) (constantly nil)
-             (fn? version) #(name (version %))
+             (fn? version) #(when-let [v (version %)] (name v))
              :else (constantly (name version)))]
     (html/transform nodes
                     (scope-selector scope)

--- a/src/glimpse/impl/default/bindings.clj
+++ b/src/glimpse/impl/default/bindings.clj
@@ -87,9 +87,9 @@
 
 (defn version
   "Gets the version from the provided data. The version is expected to exist as
-  a value associated with ::glimpse.views/version on the data."
+  a value associated with :glimpse.views/version on the data."
   [data]
-  (let [version (::glimpse.views/version data)]
+  (let [version (:glimpse.views/version data)]
     (cond
       (fn? version) (when-let [v (version data)] (name v))
       (nil? version) nil
@@ -143,7 +143,7 @@
   be selected for those data without a corresponding version.
 
   The version information may also be embedded in the data by using the
-  ::glimpse.views/version key on the data."
+  :glimpse.views/version key on the data."
   ([nodes scope data]
    (html/transform nodes
                    (scope-selector scope)
@@ -154,5 +154,5 @@
          version (if (sequential? version)
                    (resize (count data) version)
                    (repeat version))
-         data (map #(assoc %1 ::glimpse.views/version %2) data version)]
+         data (map #(assoc %1 :glimpse.views/version %2) data version)]
      (bind-scope nodes scope data))))

--- a/src/glimpse/impl/seq.clj
+++ b/src/glimpse/impl/seq.clj
@@ -1,0 +1,11 @@
+(ns glimpse.impl.seq)
+
+(defn resize
+  "Resizes a collection to be a specified size.
+
+  If the collection is smaller than n, pad the collection with a provided value
+  or nil."
+  ([n coll]
+   (resize n coll nil))
+  ([n coll val]
+   (take n (concat coll (repeat val)))))

--- a/test/glimpse/impl/default/bindings_test.clj
+++ b/test/glimpse/impl/default/bindings_test.clj
@@ -63,47 +63,47 @@
                                        "</div>"
                                        "</div>"))]
       (testing "with a single post"
-       (are [expected bindings] (= expected (render (bind-scope post :post bindings)))
-         (str "<div data-scope=\"post\">"
-              "<a data-prop=\"title\" href=\"post_link\">My Title</a>"
-              "<p data-prop=\"body\">My content</p>"
-              "</div>")
-         {:title {:href "post_link" :content "My Title"} :body "My content" :comment nil}
+        (are [expected bindings] (= expected (render (bind-scope post :post bindings)))
+          (str "<div data-scope=\"post\">"
+               "<a data-prop=\"title\" href=\"post_link\">My Title</a>"
+               "<p data-prop=\"body\">My content</p>"
+               "</div>")
+          {:title {:href "post_link" :content "My Title"} :body "My content" :comment nil}
 
-         (str "<div data-scope=\"post\">"
-              "<a data-prop=\"title\" href=\"post_link\">My Title</a>"
-              "<p data-prop=\"body\">My content</p>"
-              "</div>")
-         {:title {:href "post_link" :content "My Title"} :body "My content" :comment []}
+          (str "<div data-scope=\"post\">"
+               "<a data-prop=\"title\" href=\"post_link\">My Title</a>"
+               "<p data-prop=\"body\">My content</p>"
+               "</div>")
+          {:title {:href "post_link" :content "My Title"} :body "My content" :comment []}
 
-         (str "<div data-scope=\"post\">"
-              "<a data-prop=\"title\" href=\"post_link\">My Title</a>"
-              "<p data-prop=\"body\">My content</p>"
-              "<div data-scope=\"comment\">"
-              "<p>Author:<span data-prop=\"author\">President Lincoln</span></p>"
-              "<p data-prop=\"body\">Fourscore and seven years ago...</p>"
-              "</div>"
-              "</div>")
-         {:title {:href "post_link" :content "My Title"}
-          :body "My content"
-          :comment {:author "President Lincoln" :body "Fourscore and seven years ago..."}}
+          (str "<div data-scope=\"post\">"
+               "<a data-prop=\"title\" href=\"post_link\">My Title</a>"
+               "<p data-prop=\"body\">My content</p>"
+               "<div data-scope=\"comment\">"
+               "<p>Author:<span data-prop=\"author\">President Lincoln</span></p>"
+               "<p data-prop=\"body\">Fourscore and seven years ago...</p>"
+               "</div>"
+               "</div>")
+          {:title {:href "post_link" :content "My Title"}
+           :body "My content"
+           :comment {:author "President Lincoln" :body "Fourscore and seven years ago..."}}
 
-         (str "<div data-scope=\"post\">"
-              "<a data-prop=\"title\" href=\"post_link\">My Title</a>"
-              "<p data-prop=\"body\">My content</p>"
-              "<div data-scope=\"comment\">"
-              "<p>Author:<span data-prop=\"author\">President Lincoln</span></p>"
-              "<p data-prop=\"body\">Fourscore and seven years ago...</p>"
-              "</div>"
-              "<div data-scope=\"comment\">"
-              "<p>Author:<span data-prop=\"author\">President Roosevelt</span></p>"
-              "<p data-prop=\"body\">The only thing we have to fear is fear itself.</p>"
-              "</div>"
-              "</div>")
-         {:title {:href "post_link" :content "My Title"}
-          :body "My content"
-          :comment [{:author "President Lincoln" :body "Fourscore and seven years ago..."}
-                    {:author "President Roosevelt" :body "The only thing we have to fear is fear itself."}]}))
+          (str "<div data-scope=\"post\">"
+               "<a data-prop=\"title\" href=\"post_link\">My Title</a>"
+               "<p data-prop=\"body\">My content</p>"
+               "<div data-scope=\"comment\">"
+               "<p>Author:<span data-prop=\"author\">President Lincoln</span></p>"
+               "<p data-prop=\"body\">Fourscore and seven years ago...</p>"
+               "</div>"
+               "<div data-scope=\"comment\">"
+               "<p>Author:<span data-prop=\"author\">President Roosevelt</span></p>"
+               "<p data-prop=\"body\">The only thing we have to fear is fear itself.</p>"
+               "</div>"
+               "</div>")
+          {:title {:href "post_link" :content "My Title"}
+           :body "My content"
+           :comment [{:author "President Lincoln" :body "Fourscore and seven years ago..."}
+                     {:author "President Roosevelt" :body "The only thing we have to fear is fear itself."}]}))
 
       (testing "with multiple posts"
         (are [expected bindings] (= expected (render (bind-scope post :post bindings)))
@@ -125,9 +125,9 @@
                "<p data-prop=\"body\">My second content</p>"
                "</div>")
           [{:title {:href "post_link" :content "My Title"}
-             :body "My content"
-             :comment [{:author "President Lincoln" :body "Fourscore and seven years ago..."}
-                       {:author "President Roosevelt" :body "The only thing we have to fear is fear itself."}]}
+            :body "My content"
+            :comment [{:author "President Lincoln" :body "Fourscore and seven years ago..."}
+                      {:author "President Roosevelt" :body "The only thing we have to fear is fear itself."}]}
            {:title {:href "second_post_link" :content "My Second Title"}
             :body "My second content"
             :comment []}]
@@ -153,9 +153,9 @@
                "</div>"
                "</div>")
           [{:title {:href "post_link" :content "My Title"}
-             :body "My content"
-             :comment [{:author "President Lincoln" :body "Fourscore and seven years ago..."}
-                       {:author "President Roosevelt" :body "The only thing we have to fear is fear itself."}]}
+            :body "My content"
+            :comment [{:author "President Lincoln" :body "Fourscore and seven years ago..."}
+                      {:author "President Roosevelt" :body "The only thing we have to fear is fear itself."}]}
            {:title {:href "second_post_link" :content "My Second Title"}
             :body "My second content"
             :comment {:author "Albert Einstein"
@@ -178,19 +178,23 @@
         abbreviated-result "<div data-scope=\"post\"><h1 data-prop=\"title\">my_title</h1><p data-version=\"abbreviated\"><span data-prop=\"title\">my_title</span> - <span data-prop=\"abstract\">my_abstract</span></p></div>"
         data {:title "my_title" :full-text "my_full_text" :abstract "my_abstract"}
         abbreviated-data {:title "my_title" :abstract "my_abstract"}]
-    (are [expected version data] (= expected (render (bind-scope a :post version data)))
-      complete-result nil data
-      complete-result "complete" data
-      abbreviated-result "abbreviated" data
-      abbreviated-result :abbreviated data
-      abbreviated-result #(if (:full-text %) :complete :abbreviated) abbreviated-data)))
+    (testing "with single data binding"
+      (are [expected version data] (= expected (render (bind-scope a :post version data)))
+        complete-result nil data
+        complete-result "complete" data
+        abbreviated-result "abbreviated" data
+        abbreviated-result :abbreviated data
+        abbreviated-result #(if (:full-text %) :complete :abbreviated) abbreviated-data))
+    (testing "with collection data binding"
+      (is (= (str complete-result abbreviated-result)
+             (render (bind-scope a :post [:complete :abbreviated] [data data])))))))
 
 (deftest test-filter-version
   (let [basic-post "<div data-scope=\"post\"></div>"
         long-post "<div data-scope=\"post\"><h1 data-prop=\"title\"></h1><p data-version=\"a b\" data-default=\"\"><span data-prop=\"title\"></span> - <span data-prop=\"abstract\"></span></p><p data-version=\"c\" data-prop=\"full-text\"></p></div>"
         default-post "<div data-scope=\"post\"><h1 data-prop=\"title\"></h1><p data-version=\"a b\" data-default=\"\"><span data-prop=\"title\"></span> - <span data-prop=\"abstract\"></span></p></div>"
         c-post "<div data-scope=\"post\"><h1 data-prop=\"title\"></h1><p data-version=\"c\" data-prop=\"full-text\"></p></div>"]
-   (are [expected input version] (= expected (render (filter-version (parse-el input) version)))
-     basic-post basic-post nil
-     default-post long-post nil
-     c-post long-post "c")))
+    (are [expected input version] (= expected (render (filter-version (parse-el input) version)))
+      basic-post basic-post nil
+      default-post long-post nil
+      c-post long-post "c")))

--- a/test/glimpse/impl/seq_test.clj
+++ b/test/glimpse/impl/seq_test.clj
@@ -1,0 +1,9 @@
+(ns glimpse.impl.seq-test
+  (:require [glimpse.impl.seq :refer :all]
+            [clojure.test :refer :all]))
+
+(deftest test-resize
+  (is (= [] (resize 0 [1])))
+  (is (= [1] (resize 1 [1])))
+  (is (= [1 nil] (resize 2 [1])))
+  (is (= [1 2] (resize 2 [1] 2))))


### PR DESCRIPTION
This pull request adds support for `data-version` and `data-default` bindings, which allow the designer to defer the decision of which version of markup to render to the backend. These are similar to bindings of the same names in Pakyow, though there are some minor differences.

As a silly little example of how these might be used, let's consider two different layouts for a blog post.

``` html
<div data-scope="post">
  <h1 data-prop="title">Post Title</h1>

  <p data-default data-prop="full-text">Full Post Text</p>
  <p data-version="short" data-prop="short-text">Short Post Text</p>
</div>
```

The value of the `data-version` attribute is the name of the version. It can have multiple values (e.g., `data-version="short medium"`). Note that the `h1` element does not have a version assigned, and so it appears in every version.

To specify a version to use, support for a `:version` option has been added to the default implementation of `glimpse.views/bind`. The value can be a string or keyword that name the desired version, `nil` to indicate the default version should be used, or a function that accepts the binding data and returns a string, keyword, or `nil`.

To bind with a function, the following code might be used:

``` clojure
(glimpse.views/bind view
                    :post
                    [{:title "Full" :full-text "Some Full Text"}
                     {:title "Short" :short-text "Some Short Text" :version :short}]
                    :version #(:version %))
```

For the first piece of data, the version function returns `nil`, so the `data-default` element is used. In the second case, the function returns `short`, so the `data-version="short"` element is used.

The `:version` option on bind only works at the top level; it does not reapply the version selector to sub-scopes. The appropriate method to solve this problem is left to a future issue.

Fixes #2.
